### PR TITLE
switch base image to python:alpine so latest version of ansible can be installed

### DIFF
--- a/cluster/images/provider-ansible/Dockerfile
+++ b/cluster/images/provider-ansible/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpinelinux/ansible
-RUN apk --no-cache add ca-certificates bash
-RUN pip3 install ansible-runner
+FROM python:3.10-alpine3.17
+RUN apk --no-cache add ca-certificates bash openssh-client
+RUN python -m pip install ansible ansible-runner
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Signed-off-by: Evan Johnson <eljohn1014@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
The current base image used for this provider looks to be unmaintained for the past 3 years, this PR switches to using the official python:alpine base image and now installs both ansible and ansible-runner via pip install
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
I have test image is building successfully and both ansible and ansible-playbook are installed in the default PATH and on the latest version
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
