### PR TITLE
fix ANSIBLE_INVENTORY env varible for roles

### DIFF
--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -195,7 +195,7 @@ func (p Parameters) roleCmdFunc(ctx context.Context, roleName string, path strin
 
 		// override or omit envVar that may disturb the dc execution
 		// TODO: check if ANSIBLE_INVENTORY is useless when applying role ?
-		dc.Env = append(dc.Env, fmt.Sprintf("%s=%s", filepath.Join(p.WorkingDirPath, AnsibleInventoryPath), runnerutil.Hosts))
+		dc.Env = append(dc.Env, fmt.Sprintf("%s=%s", AnsibleInventoryPath, filepath.Join(p.WorkingDirPath, runnerutil.Hosts)))
 		return dc
 	}
 }


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This PR updates the ANSIBLE_INVENTORY variable when using a role to allow for using the absolute inventory path defined by the ansibleRun resource
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
I have validated this manually with some local cluster testing
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
