### PR TITLE
fix ansible-runner context for roles

### DIFF
--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -175,9 +175,11 @@ func (p Parameters) playbookCmdFunc(ctx context.Context, playbookName string, pa
 // roleCmdFunc mimics https://github.com/operator-framework/operator-sdk/blob/707240f006ecfc0bc86e5c21f6874d302992d598/internal/ansible/runner/runner.go#L92-L118
 func (p Parameters) roleCmdFunc(ctx context.Context, roleName string, path string) cmdFuncType {
 	return func(behaviorVars map[string]string, checkMode bool) *exec.Cmd {
-		cmdArgs := []string{"run", filepath.Join(path, roleName)}
+		cmdArgs := []string{"run", p.WorkingDirPath}
 		cmdOptions := []string{
 			"--role", roleName,
+			"--roles-path", path,
+			"--project-dir", p.WorkingDirPath,
 		}
 		// enable check mode via cmdline https://github.com/ansible/ansible-runner/issues/580
 		if checkMode {


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
sets role path and project dir correct when using roles
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #160

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
I have validated credentials mounted in /ansibleRun/UUID/<credientials> can be used correctly by an ansibleRun with this config
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
