### PR TITLE
set Credentials as optional field so it is not required for public remotes

### DIFF
--- a/apis/v1alpha1/providerconfig_types.go
+++ b/apis/v1alpha1/providerconfig_types.go
@@ -30,7 +30,8 @@ type Var struct {
 
 // A ProviderConfigSpec defines the desired state of a ProviderConfig.
 type ProviderConfigSpec struct {
-	// Credentials required to authenticate to this provider.
+	// Credentials are required to authenticate to private remote(s).
+	// +optional
 	Credentials []ProviderCredentials `json:"credentials"`
 
 	// Requirements manage the necessary dependencies to run ansible collection.

--- a/package/crds/ansible.crossplane.io_providerconfigs.yaml
+++ b/package/crds/ansible.crossplane.io_providerconfigs.yaml
@@ -44,7 +44,7 @@ spec:
             description: A ProviderConfigSpec defines the desired state of a ProviderConfig.
             properties:
               credentials:
-                description: Credentials required to authenticate to this provider.
+                description: Credentials are required to authenticate to private remote(s).
                 items:
                   description: ProviderCredentials required to authenticate.
                   properties:
@@ -124,8 +124,6 @@ spec:
                   - value
                   type: object
                 type: array
-            required:
-            - credentials
             type: object
           status:
             description: A ProviderConfigStatus reflects the observed state of a ProviderConfig.


### PR DESCRIPTION
Signed-off-by: fahed dorgaa <fahed.dorgaa@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #  https://github.com/crossplane-contrib/provider-ansible/issues/185

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
