### PR TITLE
add option to set inventory as executable

### DIFF
--- a/apis/v1alpha1/ansibleRun_types.go
+++ b/apis/v1alpha1/ansibleRun_types.go
@@ -40,6 +40,11 @@ type AnsibleRunParameters struct {
 	// +optional
 	Inventories []Inventory `json:"inventories"`
 
+	// This sets the Inventory to executable for use by ansible.builtin.script plugin
+	// +kubebuilder:default=false
+	// +optional
+	ExecutableInventory bool `json:"executableInventory"`
+
 	// The inline configuration of this AnsibleRun;  the content of a simple playbook.yml file may be written inline.
 	// This field is mutually exclusive with the “roles” field.
 	// +optional

--- a/examples/ansible/inventory/ansibleRun-executable-inventory.yml
+++ b/examples/ansible/inventory/ansibleRun-executable-inventory.yml
@@ -1,0 +1,28 @@
+apiVersion: ansible.crossplane.io/v1alpha1
+kind: AnsibleRun
+metadata:
+  name: executable-inventory
+spec:
+  forProvider:
+    executableInventory: True
+    inventoryInline: |
+      #!/usr/bin/env python3
+      import json
+      import argparse
+      if __name__ == "__main__":
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--list", action="store_true", help="Show JSON of all managed hosts")
+        parser.add_argument("--host", help="Display vars related to the host")
+        args = parser.parse_args()
+      if args.list:
+          print(json.dumps({"all": {"hosts": ["localhost"]}}, indent=4))
+      elif args.host:
+        print(json.dumps({"ansible_connection": "local"}, indent=4))
+
+    playbookInline: |
+      ---
+      - hosts: all
+        tasks:
+          - name: ansibleplaybook-simple
+            debug:
+              msg: Your are running 'ansibleplaybook-simple' example

--- a/package/crds/ansible.crossplane.io_ansibleruns.yaml
+++ b/package/crds/ansible.crossplane.io_ansibleruns.yaml
@@ -52,6 +52,11 @@ spec:
                 description: AnsibleRunParameters are the configurable fields of a
                   AnsibleRun.
                 properties:
+                  executableInventory:
+                    default: false
+                    description: This sets the Inventory to executable for use by
+                      ansible.builtin.script plugin
+                    type: boolean
                   inventories:
                     description: The Inventories of this AnsibleRun.
                     items:


### PR DESCRIPTION
Signed-off-by: Evan Johnson <eljohn1014@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This PR adds  the `executableInventory` option that extends support for [dynamic inventory scripts](https://docs.ansible.com/ansible/latest/inventory_guide/intro_dynamic_inventory.html) supported by ansible
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #192 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
