### PR TITLE
make the `AnsibleRun` resource cluster-scoped

### DIFF
--- a/apis/v1alpha1/ansibleRun_types.go
+++ b/apis/v1alpha1/ansibleRun_types.go
@@ -93,6 +93,7 @@ type AnsibleRunStatus struct {
 // AnsibleRun represents a set of Ansible Playbooks.
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:resource:scope=Cluster
 type AnsibleRun struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/package/crds/ansible.crossplane.io_ansibleruns.yaml
+++ b/package/crds/ansible.crossplane.io_ansibleruns.yaml
@@ -13,7 +13,7 @@ spec:
     listKind: AnsibleRunList
     plural: ansibleruns
     singular: ansiblerun
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
### Description of your changes

For some reason the `AnsibleRun` resource was namespaced. I couldn't find anything about that in the design doc so I assume it is a bug.

Now it's possible add `AnsibleRun` to a composition (either function or legacy p&t)

Note that this is a breaking change

Fixes: #260 #172 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
manually