### PR TITLE
set Ready condition after running ansible

### DIFF
--- a/internal/controller/ansibleRun/ansibleRun.go
+++ b/internal/controller/ansibleRun/ansibleRun.go
@@ -395,7 +395,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	// disable checkMode for real action
 	c.runner.EnableCheckMode(false)
-	if err := c.runAnsible(ctx, cr); err != nil {
+	if err := c.runAnsible(cr); err != nil {
 		return managed.ExternalUpdate{}, fmt.Errorf("running ansible: %w", err)
 	}
 
@@ -473,7 +473,7 @@ func (c *external) handleLastApplied(ctx context.Context, lastParameters *v1alph
 			return managed.ExternalObservation{}, err
 		}
 
-		if err := c.runAnsible(ctx, desired); err != nil {
+		if err := c.runAnsible(desired); err != nil {
 			return managed.ExternalObservation{}, fmt.Errorf("running ansible: %w", err)
 		}
 	}
@@ -485,7 +485,7 @@ func (c *external) handleLastApplied(ctx context.Context, lastParameters *v1alph
 	return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true}, nil
 }
 
-func (c *external) runAnsible(ctx context.Context, cr *v1alpha1.AnsibleRun) error {
+func (c *external) runAnsible(cr *v1alpha1.AnsibleRun) error {
 	dc, _, err := c.runner.Run()
 	if err != nil {
 		return err

--- a/internal/controller/ansibleRun/ansibleRun.go
+++ b/internal/controller/ansibleRun/ansibleRun.go
@@ -473,10 +473,9 @@ func (c *external) handleLastApplied(ctx context.Context, lastParameters *v1alph
 			return managed.ExternalObservation{}, err
 		}
 
-	}
-
-	if err := c.runAnsible(ctx, desired); err != nil {
-		return managed.ExternalObservation{}, fmt.Errorf("running ansible: %w", err)
+		if err := c.runAnsible(ctx, desired); err != nil {
+			return managed.ExternalObservation{}, fmt.Errorf("running ansible: %w", err)
+		}
 	}
 
 	// The crossplane runtime is not aware of the external resource created by ansible content.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #228

This sets `Ready` condition based on the result of an ansiblerun. Ansibleruns can't observed as a typical crossplane external resource, but interpreting the exit code as the availability indicator seems like the next best thing.
I'd also like to extract a better error message than just `exit code X` (which is the error message), but that requires parsing ansible logs and there's some yak shaving to do to make that possible.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

1) Deploy modified version of provider-ansible in a k8s cluster (`make local.xpkg.deploy.provider.provider-ansible`)
2) Create an ansiblerun w/ the default run policy `ObserveAndDelete`. Here's my example:
```
apiVersion: ansible.crossplane.io/v1alpha1
kind: AnsibleRun
metadata:
  annotations:
  name: test-run
spec:
  forProvider:
    executableInventory: false
    inventoryInline: |
      cluster:
        hosts:
          test:
            ansible_host: <VM IP>
    playbookInline: |
      - hosts: cluster
        tasks:
        - file:
            path: /test
            owner: root
            group: root
            mode: '0600'
            state: touch
    vars:
      ansible_ssh_private_key_file: ./ssh_id
  providerConfigRef:
    name: test-config
```
3) Observe the status of the run become
```
  - lastTransitionTime: "2024-01-18T21:23:12Z"
    reason: ReconcileSuccess
    status: "True"
    type: Synced
  - lastTransitionTime: "2024-01-18T21:23:19Z"
    reason: Available
    status: "True"
    type: Ready
```
4) Change the playbook to introduce a failure. For example,
```
 playbookInline: |
      - hosts: cluster
        tasks:
        - file:
            path: /test2
            state: file
```
5) Observe the status of the run become
```
   - lastTransitionTime: "2024-01-18T22:05:19Z"
    message: exit status 2
    reason: Unavailable
    status: "False"
    type: Ready
  - lastTransitionTime: "2024-01-18T22:05:19Z"
    reason: ReconcileSuccess
    status: "True"
    type: Synced
```
While ReconcileSuccess is true simply b/c lastappliedconfiguration matches the current spec, the resource is still marked as unavailable, as expected.

6) Repeat the process with `ansible.crossplane.io/runPolicy: CheckWhenObserve` annotation. It actually will be failing b/c of 
https://github.com/crossplane-contrib/provider-ansible/issues/290, but at least make sure no other issues were introduced.

[contribution process]: https://git.io/fj2m9
