### PR TITLE
Retry failed runs with ObserveAndDelete policy

### DIFF
--- a/internal/controller/ansibleRun/ansibleRun.go
+++ b/internal/controller/ansibleRun/ansibleRun.go
@@ -441,10 +441,8 @@ func getLastAppliedParameters(observed *v1alpha1.AnsibleRun) (*v1alpha1.AnsibleR
 	return lastParameters, nil
 }
 
-// nolint: gocyclo
-// TODO reduce cyclomatic complexity
 func (c *external) handleLastApplied(ctx context.Context, lastParameters *v1alpha1.AnsibleRunParameters, desired *v1alpha1.AnsibleRun) (managed.ExternalObservation, error) {
-	// Mark as up-to-date since last is equal to desired
+	// Mark as up-to-date if last is equal to desired
 	isUpToDate := (lastParameters != nil && equality.Semantic.DeepEqual(*lastParameters, desired.Spec.ForProvider))
 
 	isLastSyncOK := (desired.GetCondition(xpv1.TypeSynced).Status == v1.ConditionTrue)

--- a/internal/controller/ansibleRun/ansibleRun.go
+++ b/internal/controller/ansibleRun/ansibleRun.go
@@ -444,38 +444,38 @@ func getLastAppliedParameters(observed *v1alpha1.AnsibleRun) (*v1alpha1.AnsibleR
 // nolint: gocyclo
 // TODO reduce cyclomatic complexity
 func (c *external) handleLastApplied(ctx context.Context, lastParameters *v1alpha1.AnsibleRunParameters, desired *v1alpha1.AnsibleRun) (managed.ExternalObservation, error) {
-	isUpToDate := false
-	if lastParameters != nil {
-		if equality.Semantic.DeepEqual(*lastParameters, desired.Spec.ForProvider) {
-			// Mark as up-to-date since last is equal to desired
-			isUpToDate = true
-		}
+	// Mark as up-to-date since last is equal to desired
+	isUpToDate := (lastParameters != nil && equality.Semantic.DeepEqual(*lastParameters, desired.Spec.ForProvider))
+
+	isLastSyncOK := (desired.GetCondition(xpv1.TypeSynced).Status == v1.ConditionTrue)
+
+	if isUpToDate && isLastSyncOK {
+		// nothing to do for this run
+		return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true}, nil
 	}
 
-	if !isUpToDate {
-		out, err := json.Marshal(desired.Spec.ForProvider)
-		if err != nil {
-			return managed.ExternalObservation{}, err
-		}
-		// set LastAppliedConfig Annotation to avoid useless cmd run
-		meta.AddAnnotations(desired, map[string]string{
-			v1.LastAppliedConfigAnnotation: string(out),
-		})
+	out, err := json.Marshal(desired.Spec.ForProvider)
+	if err != nil {
+		return managed.ExternalObservation{}, err
+	}
+	// set LastAppliedConfig Annotation to avoid useless cmd run
+	meta.AddAnnotations(desired, map[string]string{
+		v1.LastAppliedConfigAnnotation: string(out),
+	})
 
-		if err := c.kube.Update(ctx, desired); err != nil {
-			return managed.ExternalObservation{}, err
-		}
-		stateVar := make(map[string]string)
-		stateVar["state"] = "present"
-		nestedMap := make(map[string]interface{})
-		nestedMap[desired.GetName()] = stateVar
-		if err := c.runner.WriteExtraVar(nestedMap); err != nil {
-			return managed.ExternalObservation{}, err
-		}
+	if err := c.kube.Update(ctx, desired); err != nil {
+		return managed.ExternalObservation{}, err
+	}
+	stateVar := make(map[string]string)
+	stateVar["state"] = "present"
+	nestedMap := make(map[string]interface{})
+	nestedMap[desired.GetName()] = stateVar
+	if err := c.runner.WriteExtraVar(nestedMap); err != nil {
+		return managed.ExternalObservation{}, err
+	}
 
-		if err := c.runAnsible(desired); err != nil {
-			return managed.ExternalObservation{}, fmt.Errorf("running ansible: %w", err)
-		}
+	if err := c.runAnsible(desired); err != nil {
+		return managed.ExternalObservation{}, fmt.Errorf("running ansible: %w", err)
 	}
 
 	// The crossplane runtime is not aware of the external resource created by ansible content.

--- a/internal/controller/ansibleRun/ansibleRun_test.go
+++ b/internal/controller/ansibleRun/ansibleRun_test.go
@@ -611,10 +611,7 @@ func TestObserve(t *testing.T) {
 			reason: "We should not run ansible when spec has not changed and last sync was successful",
 			fields: fields{
 				kube: &test.MockClient{
-					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
-						obj = testRunWithReconcileSuccess
-						return nil
-					}),
+					MockGet:    test.NewMockGetFn(nil),
 					MockUpdate: test.NewMockUpdateFn(nil),
 				},
 				runner: &MockRunner{
@@ -642,10 +639,7 @@ func TestObserve(t *testing.T) {
 			reason: "We should run ansible when spec has not changed but last sync was unsuccessful",
 			fields: fields{
 				kube: &test.MockClient{
-					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
-						obj = testRunWithReconcileError
-						return nil
-					}),
+					MockGet:    test.NewMockGetFn(nil),
 					MockUpdate: test.NewMockUpdateFn(nil),
 				},
 				runner: &MockRunner{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #295
On backoff: Since `Observe` returns error whenever a retry run fails, crossplane-runtime will [automatically apply backoff](https://github.com/crossplane/crossplane-runtime/blob/e0bda77c3c946bfe0914cd871143038ad32a13bc/pkg/reconciler/managed/reconciler.go#L917)
We don't have control over the interval, max steps etc., but it's going to be the same default backoff that crossplane-runtime applies whenever `Update` fails, so we should have the bahavior that matches `CheckWhenObserve` policy's updates, and also matches other providers.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

1. Deploy modified version of provider-ansible in a k8s cluster (make local.xpkg.deploy.provider.provider-ansible)
2. Create an ansiblerun w/ the default run policy ObserveAndDelete and a playbook that will fail. Here's my example:
```
apiVersion: ansible.crossplane.io/v1alpha1
kind: AnsibleRun
metadata:
  annotations:
  name: test-run
spec:
  forProvider:
    executableInventory: false
    inventoryInline: |
      cluster:
        hosts:
          test:
            ansible_host: <VM IP>
    playbookInline: |
      - hosts: cluster
        tasks:
        - file:
            path: /test-file-missing
            state: present
    vars:
      ansible_ssh_private_key_file: ./ssh_id
  providerConfigRef:
    name: test-config
3. Watch the logs to see retries
4. Fix the playbook, e.g.:
 playbookInline: |
      - hosts: cluster
        tasks:
        - file:
            path: /test-file-missing
            state: touch
5. Check the logs to see that, after a successful run, no more runs happen during regular sync.

[contribution process]: https://git.io/fj2m9
