### PR TITLE
use dumb-init so that orphaned children processes get cleaned up

### DIFF
--- a/cluster/images/provider-ansible/Dockerfile
+++ b/cluster/images/provider-ansible/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /wheels
 RUN python -m pip wheel ansible ansible-runner --wheel-dir=/wheels
 
 FROM python:3.10-alpine3.17
-RUN apk --no-cache add ca-certificates bash openssh-client git
+RUN apk --no-cache add ca-certificates bash openssh-client git dumb-init
 COPY --from=build-base /wheels/* /wheels/
 RUN python -m pip install --no-index --find-links=/wheels ansible ansible-runner && \
     rm -r /wheels
@@ -25,4 +25,4 @@ RUN chown ansible /ansibleDir /.ansible
 
 EXPOSE 8080
 USER ansible
-ENTRYPOINT ["crossplane-ansible-provider"]
+ENTRYPOINT ["/usr/bin/dumb-init", "crossplane-ansible-provider"]


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #304
dumb-init becomes the process with PID 1 and actually does the things that an init system is expected to do, like waiting on orphaned children and cleaning them up

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Exec into the provider-ansible pod and run `top`
While that's running, create some ansibleruns (pretty much any of them orphan `ssh` processes, some also orphan ansible-playbook processes - like when the run times out)
Watch that all processes spun up from the runs get cleaned up from the table after the run is finished

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
