### PR TITLE
parse job events to extract failure messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/crossplane/crossplane-runtime v0.19.2
 	github.com/crossplane/crossplane-tools v0.0.0-20220310165030-1f43fc12793e
 	github.com/google/go-cmp v0.5.9
+	github.com/google/uuid v1.3.0
 	github.com/spf13/afero v1.9.5
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.4.0
@@ -40,7 +41,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -447,9 +447,9 @@ func parseEvents(dir string) ([]jobEvent, error) {
 		return nil, fmt.Errorf("reading job events directory: %w", err)
 	}
 
-	var evts []jobEvent
-	for _, file := range files {
-		evtBytes, err := os.ReadFile(filepath.Join(dir, file.Name()))
+	evts := make([]jobEvent, len(files))
+	for i, file := range files {
+		evtBytes, err := os.ReadFile(filepath.Clean(filepath.Join(dir, file.Name())))
 		if err != nil {
 			return nil, fmt.Errorf("reading job event file %q: %w", file.Name(), err)
 		}
@@ -458,7 +458,7 @@ func parseEvents(dir string) ([]jobEvent, error) {
 		if err := json.Unmarshal(evtBytes, &evt); err != nil {
 			return nil, fmt.Errorf("unmarshaling job event from file %q: %w", file.Name(), err)
 		}
-		evts = append(evts, evt)
+		evts[i] = evt
 	}
 
 	return evts, nil

--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -450,7 +450,7 @@ func parseEvents(ctx context.Context, dir string) ([]jobEvent, error) {
 		return nil, fmt.Errorf("reading job events directory %q: %w", dir, err)
 	}
 
-	var evts []jobEvent
+	evts := make([]jobEvent, 0)
 	for _, file := range files {
 		evtBytes, err := os.ReadFile(filepath.Clean(filepath.Join(dir, file.Name())))
 		if err != nil {

--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -28,6 +28,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/apenella/go-ansible/pkg/stdoutcallback/results"
@@ -36,7 +37,9 @@ import (
 	"github.com/crossplane-contrib/provider-ansible/pkg/runnerutil"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -133,10 +136,10 @@ func withBehaviorVars(behaviorVars map[string]string) runnerOption {
 	}
 }
 
-// withAnsibleEnvDir set the runner env/extravars dir.
-func withAnsibleEnvDir(dir string) runnerOption {
+// withWorkDir set the runner working dir.
+func withWorkDir(dir string) runnerOption {
 	return func(r *Runner) {
-		r.AnsibleEnvDir = dir
+		r.workDir = dir
 	}
 }
 
@@ -312,14 +315,16 @@ func (p Parameters) Init(ctx context.Context, cr *v1alpha1.AnsibleRun, behaviorV
 		return nil, err
 	}
 
-	return new(withPath(path),
+	r := new(withPath(path),
 		withCmdFunc(cmdFunc),
 		withBehaviorVars(behaviorVars),
 		withAnsibleRunPolicy(rPolicy),
 		// TODO should be moved to connect() func
-		withAnsibleEnvDir(ansibleEnvDir),
+		withWorkDir(p.WorkingDirPath),
 		withArtifactsHistoryLimit(p.ArtifactsHistoryLimit),
-	), nil
+	)
+
+	return r, nil
 }
 
 // Runner struct holds the configuration to run the cmdFunc
@@ -327,6 +332,7 @@ type Runner struct {
 	Path                  string // absolute path on disk to a playbook or role depending on what cmdFunc expects
 	behaviorVars          map[string]string
 	cmdFunc               cmdFuncType // returns a Cmd that runs ansible-runner
+	workDir               string
 	AnsibleEnvDir         string
 	checkMode             bool
 	AnsibleRunPolicy      *RunPolicy
@@ -350,8 +356,12 @@ func (r *Runner) GetAnsibleRunPolicy() *RunPolicy {
 	return r.AnsibleRunPolicy
 }
 
+func (r *Runner) ansibleEnvDir() string {
+	return filepath.Clean(filepath.Join(r.workDir, "env"))
+}
+
 // Run execute the appropriate cmdFunc
-func (r *Runner) Run() (*exec.Cmd, io.Reader, error) {
+func (r *Runner) Run(ctx context.Context) (io.Reader, error) {
 	var (
 		stdoutBuf                  bytes.Buffer
 		stdoutWriter, stderrWriter io.Writer
@@ -359,6 +369,10 @@ func (r *Runner) Run() (*exec.Cmd, io.Reader, error) {
 
 	dc := r.cmdFunc(r.behaviorVars, r.checkMode)
 	dc.Args = append(dc.Args, "--rotate-artifacts", strconv.Itoa(r.artifactsHistoryLimit))
+
+	id := uuid.New().String()
+	dc.Args = append(dc.Args, "--ident", id)
+
 	if !r.checkMode {
 		// for disabled checkMode dc.Stdout and dc.Stderr are respectfully
 		// written to os.Stdout and os.Stdout for debugging purpose
@@ -383,10 +397,95 @@ func (r *Runner) Run() (*exec.Cmd, io.Reader, error) {
 
 	err := dc.Start()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return dc, &stdoutBuf, nil
+	if err := dc.Wait(); err != nil {
+		jobEventsDir := filepath.Clean(filepath.Join(r.workDir, "artifacts", id, "job_events"))
+		failureReason, reasonErr := extractFailureReason(jobEventsDir)
+		if reasonErr != nil {
+			log.FromContext(ctx).Error(err, "extracting ansible failure message")
+		}
+
+		return nil, fmt.Errorf("%w: %s", err, failureReason)
+	}
+
+	return &stdoutBuf, nil
+}
+
+func extractFailureReason(eventsDir string) (string, error) {
+	evts, err := parseEvents(eventsDir)
+	if err != nil {
+		return "", fmt.Errorf("parsing job events: %w", err)
+	}
+
+	var msgs []string
+	for _, evt := range evts {
+		switch evt.Event {
+		case eventTypeRunnerFailed:
+			m, err := runnerEventMessage(evt, "Failed")
+			if err != nil {
+				return "", err
+			}
+			msgs = append(msgs, m)
+		case eventTypeRunnerUnreachable:
+			m, err := runnerEventMessage(evt, "Unreachable")
+			if err != nil {
+				return "", err
+			}
+			msgs = append(msgs, m)
+		default:
+		}
+	}
+
+	return strings.Join(msgs, "; "), nil
+}
+
+func parseEvents(dir string) ([]jobEvent, error) {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading job events directory: %w", err)
+	}
+
+	var evts []jobEvent
+	for _, file := range files {
+		evtBytes, err := os.ReadFile(filepath.Join(dir, file.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("reading job event file %q: %w", file.Name(), err)
+		}
+
+		var evt jobEvent
+		if err := json.Unmarshal(evtBytes, &evt); err != nil {
+			return nil, fmt.Errorf("unmarshaling job event from file %q: %w", file.Name(), err)
+		}
+		evts = append(evts, evt)
+	}
+
+	return evts, nil
+}
+
+func reunmarshal(data map[string]any, result any) error {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshaling: %w", err)
+	}
+
+	return json.Unmarshal(b, result)
+}
+
+func runnerEventMessage(evt jobEvent, reason string) (string, error) {
+	var evtData runnerEventData
+	if err := reunmarshal(evt.EventData, &evtData); err != nil {
+		return "", fmt.Errorf("unmarshaling job event %s as runner event: %w", evt.UUID, err)
+	}
+
+	return fmt.Sprintf("%s on play %q, task %q, host %q: %s",
+		reason,
+		evtData.Play,
+		evtData.Task,
+		evtData.Host,
+		evtData.Result.Msg), nil
+
 }
 
 // selectRolePath will determines the role path
@@ -435,7 +534,7 @@ func addFile(path string, content []byte) error {
 // WriteExtraVar write extra var to env/extravars under working directory
 // it creates a non-existent env/extravars file
 func (r *Runner) WriteExtraVar(extraVar map[string]interface{}) error {
-	extraVarsPath := filepath.Join(r.AnsibleEnvDir, "extravars")
+	extraVarsPath := filepath.Join(r.ansibleEnvDir(), "extravars")
 	contentVars := make(map[string]interface{})
 	data, err := os.ReadFile(filepath.Clean(extraVarsPath))
 	if err != nil {

--- a/internal/ansible/ansible_test.go
+++ b/internal/ansible/ansible_test.go
@@ -18,6 +18,7 @@ package ansible
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -228,6 +229,82 @@ func TestRun(t *testing.T) {
 
 			if string(out) != tc.expectedOutput {
 				t.Errorf("Unexpected output in the command buffer %q, want %q", string(out), tc.expectedOutput)
+			}
+		})
+	}
+}
+
+func TestExtractFailureReason(t *testing.T) {
+	playbookStartEvt := `
+	{
+		"uuid": "63a52ed5-a403-4512-a430-c95f62fa3424",
+		"event": "playbook_on_start",
+		"event_data": {
+			"playbook": "playbook.yml"
+		}
+	}
+	`
+
+	runnerFailedEvt := `
+	{
+		"uuid": "7097758b-1109-4fd9-af59-f545633794dd",
+		"event": "runner_on_failed",
+		"event_data": {
+			"play": "test",
+			"task": "file",
+			"host": "testhost",
+			"res": {"msg": "fake error"}
+		}
+	}
+	`
+
+	runnerUnreachableEvt := `
+	{
+		"uuid": "ded6289b-e557-48c1-88e1-88eb630aec21",
+		"event": "runner_on_unreachable",
+		"event_data": {
+			"play": "test",
+			"task": "Gathering Facts",
+			"host": "testhost",
+			"res": {"msg": "Failed to connect to the host via ssh"}
+		}
+	}
+	`
+
+	cases := map[string]struct {
+		events         []string
+		expectedReason string
+	}{
+		"NoEvents": {},
+		"NoFailedEvents": {
+			events: []string{playbookStartEvt},
+		},
+		"FailedEvent": {
+			events:         []string{playbookStartEvt, runnerFailedEvt},
+			expectedReason: `Failed on play "test", task "file", host "testhost": fake error`,
+		},
+		"UnreachableEvent": {
+			events:         []string{playbookStartEvt, runnerUnreachableEvt},
+			expectedReason: `Unreachable on play "test", task "Gathering Facts", host "testhost": Failed to connect to the host via ssh`,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			for i, evt := range tc.events {
+				if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("%d.json", i)), []byte(evt), 0600); err != nil {
+					t.Fatalf("Writing test event to file: %v", err)
+				}
+			}
+
+			reason, err := extractFailureReason(dir)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if reason != tc.expectedReason {
+				t.Errorf("Unexpected reason %v, expected %v", reason, tc.expectedReason)
 			}
 		})
 	}

--- a/internal/ansible/ansible_test.go
+++ b/internal/ansible/ansible_test.go
@@ -189,7 +189,8 @@ func TestRun(t *testing.T) {
 	runner := &Runner{
 		Path: dir,
 		cmdFunc: func(_ map[string]string, _ bool) *exec.Cmd {
-			// echo works well for testing cause it will just print all the args and flags it doesn't recognize and return success
+			// echo works well for testing cause it will just print all the args and flags it doesn't recognize and return success,
+			// therefore checking its output also checks the args passed to it are correct
 			return exec.CommandContext(context.Background(), "echo")
 		},
 		AnsibleEnvDir:         filepath.Join(dir, "env"),
@@ -198,7 +199,6 @@ func TestRun(t *testing.T) {
 	}
 
 	expectedArgs := []string{"--rotate-artifacts", "3"}
-	expectedCmd := exec.Command(runner.cmdFunc(nil, false).Path, expectedArgs...)
 
 	testCases := map[string]struct {
 		checkMode      bool
@@ -216,17 +216,9 @@ func TestRun(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			runner.checkMode = tc.checkMode
-			cmd, outBuf, err := runner.Run()
+			outBuf, err := runner.Run(context.Background())
 			if err != nil {
 				t.Fatalf("Unexpected Run() error: %v", err)
-			}
-
-			if cmd.String() != expectedCmd.String() {
-				t.Errorf("Unexpected command %q expected %q", expectedCmd.String(), cmd.String())
-			}
-
-			if err := cmd.Wait(); err != nil {
-				t.Fatalf("Unexpected cmd.Wait() error: %v", err)
 			}
 
 			out, err := io.ReadAll(outBuf)

--- a/internal/ansible/ansible_test.go
+++ b/internal/ansible/ansible_test.go
@@ -304,7 +304,7 @@ func TestExtractFailureReason(t *testing.T) {
 				}
 			}
 
-			reason, err := extractFailureReason(dir)
+			reason, err := extractFailureReason(context.Background(), dir)
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}

--- a/internal/ansible/jobEvent.go
+++ b/internal/ansible/jobEvent.go
@@ -1,0 +1,27 @@
+package ansible
+
+const (
+	// https://github.com/ansible/awx/blob/devel/docs/job_events.md#job-event-relationships
+	// outlines various event types and the relationships between them
+	eventTypeRunnerFailed      = "runner_on_failed"
+	eventTypeRunnerUnreachable = "runner_on_unreachable"
+)
+
+// jobEvent represents [ansible-runner's job events](https://ansible.readthedocs.io/projects/runner/en/stable/intro/#artifactevents)
+type jobEvent struct {
+	UUID      string         `json:"uuid"`
+	Stdout    string         `json:"stdout"`
+	Event     string         `json:"event"`
+	EventData map[string]any `json:"event_data"`
+}
+
+type runnerEventData struct {
+	Play   string       `json:"play"`
+	Task   string       `json:"task"`
+	Host   string       `json:"host"`
+	Result runnerResult `json:"res"`
+}
+
+type runnerResult struct {
+	Msg string `json:"msg"`
+}

--- a/internal/controller/ansibleRun/ansibleRun_test.go
+++ b/internal/controller/ansibleRun/ansibleRun_test.go
@@ -757,6 +757,9 @@ func TestCreateOrUpdate(t *testing.T) {
 				mg: &v1alpha1.AnsibleRun{},
 			},
 			fields: fields{
+				kube: &test.MockClient{
+					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+				},
 				runner: &MockRunner{
 					MockAnsibleRunPolicy: func() *ansible.RunPolicy {
 						return &ansible.RunPolicy{
@@ -809,6 +812,9 @@ func TestCreateOrUpdate(t *testing.T) {
 				mg:  &v1alpha1.AnsibleRun{},
 			},
 			fields: fields{
+				kube: &test.MockClient{
+					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+				},
 				runner: &MockRunner{
 					MockAnsibleRunPolicy: func() *ansible.RunPolicy {
 						return &ansible.RunPolicy{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Follow-up for https://github.com/crossplane-contrib/provider-ansible/issues/228
In https://github.com/crossplane-contrib/provider-ansible/pull/294, we set the `Ready` condition, but the message on the condition was just the ansible-runner's exit code.
In this PR, the message is enhanced with the failure reason(s) from ansible logs.

Btw, parsing these job events can also help with https://github.com/crossplane-contrib/provider-ansible/issues/290 - there's a "summary" event at the end of playbook execution wich has the same info as ansible summary in the logs

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Created an ansiblerun with a failure, an unreachable host, and successful execution.
Here are examples of the conditions of the failed ones:
```
  - lastTransitionTime: "2024-02-15T22:29:06Z"
    message: 'observe failed: running ansible: exit status 2: Failed on play "test",
      task "file", host "test": file (/test4) is absent, cannot continue'
    reason: ReconcileError
    status: "False"
    type: Synced

```
```
  - lastTransitionTime: "2024-02-15T19:55:58Z"
    message: 'observe failed: running ansible: exit status 4: Unreachable on play
      "test", task "Gathering Facts", host "test": Failed to connect to the host via
      ssh: root@172.234.31.205: Permission denied (publickey,password).'
    reason: ReconcileError
    status: "False"
    type: Synced
```

[contribution process]: https://git.io/fj2m9
