### PR TITLE
limit the number of artifacts directories retained on disk

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -42,6 +42,7 @@ func main() {
 		timeout                = app.Flag("timeout", "Controls how long Ansible processes may run before they are killed.").Default("20m").Duration()
 		leaderElection         = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").OverrideDefaultFromEnvar("LEADER_ELECTION").Bool()
 		maxReconcileRate       = app.Flag("max-reconcile-rate", "The maximum number of concurrent reconciliation operations.").Default("1").Int()
+		artifactsHistoryLimit  = app.Flag("artifacts-history-limit", "Each attempt to run the playbook/role generates a set of artifacts on disk. This settings limits how many of these to keep.").Default("50").Int()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
@@ -76,6 +77,6 @@ func main() {
 		Features:                &feature.Flags{},
 	}
 
-	kingpin.FatalIfError(ansible.Setup(mgr, o, *ansibleCollectionsPath, *ansibleRolesPath, *timeout), "Cannot setup Ansible controllers")
+	kingpin.FatalIfError(ansible.Setup(mgr, o, *ansibleCollectionsPath, *ansibleRolesPath, *timeout, *artifactsHistoryLimit), "Cannot setup Ansible controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 }

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/crossplane-contrib/provider-ansible/apis"
 	ansible "github.com/crossplane-contrib/provider-ansible/internal/controller"
+	ansiblerun "github.com/crossplane-contrib/provider-ansible/internal/controller/ansibleRun"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -42,7 +43,7 @@ func main() {
 		timeout                = app.Flag("timeout", "Controls how long Ansible processes may run before they are killed.").Default("20m").Duration()
 		leaderElection         = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").OverrideDefaultFromEnvar("LEADER_ELECTION").Bool()
 		maxReconcileRate       = app.Flag("max-reconcile-rate", "The maximum number of concurrent reconciliation operations.").Default("1").Int()
-		artifactsHistoryLimit  = app.Flag("artifacts-history-limit", "Each attempt to run the playbook/role generates a set of artifacts on disk. This settings limits how many of these to keep.").Default("50").Int()
+		artifactsHistoryLimit  = app.Flag("artifacts-history-limit", "Each attempt to run the playbook/role generates a set of artifacts on disk. This settings limits how many of these to keep.").Default("10").Int()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
@@ -77,6 +78,12 @@ func main() {
 		Features:                &feature.Flags{},
 	}
 
-	kingpin.FatalIfError(ansible.Setup(mgr, o, *ansibleCollectionsPath, *ansibleRolesPath, *timeout, *artifactsHistoryLimit), "Cannot setup Ansible controllers")
+	ansibleOpts := ansiblerun.SetupOptions{
+		AnsibleCollectionsPath: *ansibleCollectionsPath,
+		AnsibleRolesPath:       *ansibleRolesPath,
+		Timeout:                *timeout,
+		ArtifactsHistoryLimit:  *artifactsHistoryLimit,
+	}
+	kingpin.FatalIfError(ansible.Setup(mgr, o, ansibleOpts), "Cannot setup Ansible controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 }

--- a/internal/controller/ansible.go
+++ b/internal/controller/ansible.go
@@ -28,12 +28,12 @@ import (
 
 // Setup creates all Template controllers with the supplied logger and adds them to
 // the supplied manager.
-func Setup(mgr ctrl.Manager, o controller.Options, ansibleCollectionsPath, ansibleRolesPath string, timeout time.Duration) error {
-	for _, setup := range []func(ctrl.Manager, controller.Options, string, string, time.Duration) error{
+func Setup(mgr ctrl.Manager, o controller.Options, ansibleCollectionsPath, ansibleRolesPath string, timeout time.Duration, artifactsHistoryLimit int) error {
+	for _, setup := range []func(ctrl.Manager, controller.Options, string, string, time.Duration, int) error{
 		config.Setup,
 		ansiblerun.Setup,
 	} {
-		if err := setup(mgr, o, ansibleCollectionsPath, ansibleRolesPath, timeout); err != nil {
+		if err := setup(mgr, o, ansibleCollectionsPath, ansibleRolesPath, timeout, artifactsHistoryLimit); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/ansible.go
+++ b/internal/controller/ansible.go
@@ -17,8 +17,6 @@ limitations under the License.
 package controller
 
 import (
-	"time"
-
 	ansiblerun "github.com/crossplane-contrib/provider-ansible/internal/controller/ansibleRun"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -28,14 +26,14 @@ import (
 
 // Setup creates all Template controllers with the supplied logger and adds them to
 // the supplied manager.
-func Setup(mgr ctrl.Manager, o controller.Options, ansibleCollectionsPath, ansibleRolesPath string, timeout time.Duration, artifactsHistoryLimit int) error {
-	for _, setup := range []func(ctrl.Manager, controller.Options, string, string, time.Duration, int) error{
-		config.Setup,
-		ansiblerun.Setup,
-	} {
-		if err := setup(mgr, o, ansibleCollectionsPath, ansibleRolesPath, timeout, artifactsHistoryLimit); err != nil {
-			return err
-		}
+func Setup(mgr ctrl.Manager, o controller.Options, s ansiblerun.SetupOptions) error {
+	if err := config.Setup(mgr, o); err != nil {
+		return err
 	}
+
+	if err := ansiblerun.Setup(mgr, o, s); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/internal/controller/ansibleRun/ansibleRun.go
+++ b/internal/controller/ansibleRun/ansibleRun.go
@@ -91,7 +91,7 @@ type ansibleRunner interface {
 }
 
 // Setup adds a controller that reconciles AnsibleRun managed resources.
-func Setup(mgr ctrl.Manager, o controller.Options, ansibleCollectionsPath, ansibleRolesPath string, timeout time.Duration) error {
+func Setup(mgr ctrl.Manager, o controller.Options, ansibleCollectionsPath, ansibleRolesPath string, timeout time.Duration, artifactsHistoryLimit int) error {
 	name := managed.ControllerName(v1alpha1.AnsibleRunGroupKind)
 
 	fs := afero.Afero{Fs: afero.NewOsFs()}
@@ -111,11 +111,12 @@ func Setup(mgr ctrl.Manager, o controller.Options, ansibleCollectionsPath, ansib
 		fs:    fs,
 		ansible: func(dir string) params {
 			return ansible.Parameters{
-				WorkingDirPath:  dir,
-				GalaxyBinary:    galaxyBinary,
-				RunnerBinary:    runnerBinary,
-				CollectionsPath: ansibleCollectionsPath,
-				RolesPath:       ansibleRolesPath,
+				WorkingDirPath:        dir,
+				GalaxyBinary:          galaxyBinary,
+				RunnerBinary:          runnerBinary,
+				CollectionsPath:       ansibleCollectionsPath,
+				RolesPath:             ansibleRolesPath,
+				ArtifactsHistoryLimit: artifactsHistoryLimit,
 			}
 		},
 	}

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -33,7 +33,7 @@ import (
 
 // Setup adds a controller that reconciles ProviderConfigs by accounting for
 // their current usage.
-func Setup(mgr ctrl.Manager, o controller.Options, _, _ string, _ time.Duration) error {
+func Setup(mgr ctrl.Manager, o controller.Options, _, _ string, _ time.Duration, _ int) error {
 	name := providerconfig.ControllerName(v1alpha1.ProviderConfigGroupKind)
 
 	of := resource.ProviderConfigKinds{

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -17,8 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"time"
-
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -33,7 +31,7 @@ import (
 
 // Setup adds a controller that reconciles ProviderConfigs by accounting for
 // their current usage.
-func Setup(mgr ctrl.Manager, o controller.Options, _, _ string, _ time.Duration, _ int) error {
+func Setup(mgr ctrl.Manager, o controller.Options) error {
 	name := providerconfig.ControllerName(v1alpha1.ProviderConfigGroupKind)
 
 	of := resource.ProviderConfigKinds{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #311 

This prevents too much data from accumulating on disk, especially now that retries are happening since each retry creates an artifacts directory.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
1) Create an ansiblerun - a failing one is best cause it'll be retried without one having to change the spec
2) exec into the provider-ansible pod, navigate to `ansibleDir/$UID-of-the-run/artifacts`
3) watch that the number of directories never exceeds the limit (you might want to set a limit lower than default for speedy testing)

[contribution process]: https://git.io/fj2m9
