### PR TITLE
respect ignore_errors when extracting error messages from event data

### DIFF
--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -430,13 +430,17 @@ func extractFailureReason(ctx context.Context, eventsDir string) (string, error)
 			if err != nil {
 				return "", err
 			}
-			msgs = append(msgs, m)
+			if m != "" {
+				msgs = append(msgs, m)
+			}
 		case eventTypeRunnerUnreachable:
 			m, err := runnerEventMessage(evt, "Unreachable")
 			if err != nil {
 				return "", err
 			}
-			msgs = append(msgs, m)
+			if m != "" {
+				msgs = append(msgs, m)
+			}
 		default:
 		}
 	}
@@ -482,6 +486,9 @@ func runnerEventMessage(evt jobEvent, reason string) (string, error) {
 	var evtData runnerEventData
 	if err := reunmarshal(evt.EventData, &evtData); err != nil {
 		return "", fmt.Errorf("unmarshaling job event %s as runner event: %w", evt.UUID, err)
+	}
+	if evtData.IgnoreErrors {
+		return "", nil
 	}
 
 	return fmt.Sprintf("%s on play %q, task %q, host %q: %s",

--- a/internal/ansible/ansible_test.go
+++ b/internal/ansible/ansible_test.go
@@ -264,6 +264,20 @@ func TestExtractFailureReason(t *testing.T) {
 	}
 	`
 
+	runnerFailedIgnoreErrorsEvt := `
+	{
+		"uuid": "7097758b-1109-4fd9-af59-f545633794dd",
+		"event": "runner_on_failed",
+		"event_data": {
+			"play": "test",
+			"task": "file",
+			"host": "testhost",
+			"res": {"msg": "fake error"},
+			"ignore_errors": true
+		}
+	}
+	`
+
 	runnerUnreachableEvt := `
 	{
 		"uuid": "ded6289b-e557-48c1-88e1-88eb630aec21",
@@ -288,6 +302,10 @@ func TestExtractFailureReason(t *testing.T) {
 		"FailedEvent": {
 			events:         []string{playbookStartEvt, runnerFailedEvt},
 			expectedReason: `Failed on play "test", task "file", host "testhost": fake error`,
+		},
+		"FailedEventWithIgnoreErrors": {
+			events:         []string{playbookStartEvt, runnerFailedIgnoreErrorsEvt},
+			expectedReason: "",
 		},
 		"UnreachableEvent": {
 			events:         []string{playbookStartEvt, runnerUnreachableEvt},

--- a/internal/ansible/jobEvent.go
+++ b/internal/ansible/jobEvent.go
@@ -16,10 +16,11 @@ type jobEvent struct {
 }
 
 type runnerEventData struct {
-	Play   string       `json:"play"`
-	Task   string       `json:"task"`
-	Host   string       `json:"host"`
-	Result runnerResult `json:"res"`
+	Play         string       `json:"play"`
+	Task         string       `json:"task"`
+	Host         string       `json:"host"`
+	Result       runnerResult `json:"res"`
+	IgnoreErrors bool         `json:"ignore_errors"`
 }
 
 type runnerResult struct {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #328 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Create an ansiblerun with a task that is known to fail but set `ignore_errors` to true, i.e.
```
     tasks:
        - ignore_errors: true
          file:
            path: /nonexistent
            state: file
```
And have that run fail for some _other_ reason (i.e. another task that fails and does _not_ have ignore_errors set).
The failed ansiblerun should have a message about the faile task _without_ ignore_errors, but should _not_ have any messages about the one with `ignore_errors`

[contribution process]: https://git.io/fj2m9
