### PR TITLE
Add sshpass to Dockerfile dependencies

### DIFF
--- a/cluster/images/provider-ansible/Dockerfile
+++ b/cluster/images/provider-ansible/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /wheels
 RUN python -m pip wheel ansible ansible-runner distlib --wheel-dir=/wheels
 
 FROM python:3.10-alpine3.17
-RUN apk --no-cache add ca-certificates bash openssh-client git dumb-init
+RUN apk --no-cache add ca-certificates bash openssh-client git dumb-init sshpass
 COPY --from=build-base /wheels/* /wheels/
 RUN python -m pip install --no-index --find-links=/wheels ansible ansible-runner distlib && \
     rm -r /wheels


### PR DESCRIPTION
Hi Folks,

`sshpass` is added to support non-interactive SSH password authentication in Ansible tasks. This enhancement ensures better compatibility and functionality for automation workflows relying on SSH connections.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane-contrib/provider-ansible/issues/356

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
