### PR TITLE
fix: use provider-specific annotation for change detection

### DIFF
--- a/internal/controller/ansibleRun/ansibleRun.go
+++ b/internal/controller/ansibleRun/ansibleRun.go
@@ -58,7 +58,14 @@ import (
 )
 
 const (
-	errNotAnsibleRun       = "managed resource is not a AnsibleRun custom resource"
+	// lastAppliedAnnotation is a provider-specific annotation used to cache
+	// the last-applied ForProvider parameters for change detection.
+	// This intentionally avoids kubectl.kubernetes.io/last-applied-configuration
+	// which expects a full Kubernetes object and conflicts with providers
+	// (like provider-kubernetes) that read it during observe/delete.
+	lastAppliedAnnotation = "ansible.crossplane.io/last-applied-parameters"
+
+	errNotAnsibleRun = "managed resource is not a AnsibleRun custom resource"
 	errTrackPCUsage        = "cannot track ProviderConfig usage"
 	errGetPC               = "cannot get ProviderConfig"
 	errGetCreds            = "cannot get credentials"
@@ -457,7 +464,7 @@ func (c *external) Delete(ctx context.Context, cr *v1alpha1.AnsibleRun) (managed
 }
 
 func getLastAppliedParameters(observed *v1alpha1.AnsibleRun) (*v1alpha1.AnsibleRunParameters, error) {
-	lastApplied, ok := observed.GetAnnotations()[v1.LastAppliedConfigAnnotation]
+	lastApplied, ok := observed.GetAnnotations()[lastAppliedAnnotation]
 	if !ok {
 		return nil, nil
 	}
@@ -490,7 +497,7 @@ func (c *external) handleLastApplied(ctx context.Context, lastParameters *v1alph
 	}
 	// set LastAppliedConfig Annotation to avoid useless cmd run
 	meta.AddAnnotations(desired, map[string]string{
-		v1.LastAppliedConfigAnnotation: string(out),
+		lastAppliedAnnotation: string(out),
 	})
 
 	if err := c.kube.Update(ctx, desired); err != nil {

--- a/internal/controller/ansibleRun/ansibleRun_test.go
+++ b/internal/controller/ansibleRun/ansibleRun_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/spf13/afero"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -540,7 +539,7 @@ func TestObserve(t *testing.T) {
 	testRun := v1alpha1.AnsibleRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				v1.LastAppliedConfigAnnotation: fmt.Sprintf(`{"playbookInline":"%s"}`, testPlaybook),
+				lastAppliedAnnotation: fmt.Sprintf(`{"playbookInline":"%s"}`, testPlaybook),
 			},
 		},
 		Spec: v1alpha1.AnsibleRunSpec{


### PR DESCRIPTION
## Summary

- Replace `kubectl.kubernetes.io/last-applied-configuration` with a provider-specific annotation `ansible.crossplane.io/last-applied-parameters` for caching ForProvider parameters during change detection
- Remove unused `v1 "k8s.io/api/core/v1"` import from tests

## Problem

provider-ansible uses `kubectl.kubernetes.io/last-applied-configuration` to store only `spec.forProvider` fields for change detection. This annotation is standardized by `kubectl apply` and other providers (like provider-kubernetes) which expect it to contain a **full Kubernetes object** with `apiVersion`, `kind`, and `metadata`.

When an `AnsibleRun` is managed via a provider-kubernetes `Object` resource, both providers write to the same annotation with incompatible formats:

| Writer | Content |
|--------|---------|
| provider-kubernetes | Full K8s object JSON (`apiVersion`, `kind`, `metadata`, `spec`) |
| provider-ansible | Only `spec.forProvider` fields (`playbookInline`, `vars`, etc.) |

On deletion, provider-kubernetes reads the annotation, attempts to unmarshal it as an `*unstructured.Unstructured` object, and fails:

```
Object 'Kind' is missing in '{"inventoryInline":null,"playbookInline":"..."}'
```

This leaves the `Object` resource stuck indefinitely with a finalizer that cannot be removed.

## Fix

Introduce `ansible.crossplane.io/last-applied-parameters` as a provider-specific annotation for change detection. This eliminates the conflict since each provider now uses its own annotation.

## Upgrade notes

On first reconcile after upgrade, existing `AnsibleRun` resources will re-run their playbook once (the old annotation key won't be found at the new key, so provider-ansible treats it as changed). This is safe as playbooks should be idempotent.

## Test plan

- [x] `go build ./internal/controller/ansibleRun/` passes
- [x] `go test ./internal/controller/ansibleRun/` passes
- [ ] Deploy updated provider-ansible and verify AnsibleRun wrapped in provider-kubernetes Object can be created and deleted without stuck finalizers

🤖 Generated with [Claude Code](https://claude.com/claude-code)