### PR TITLE
fix: replace hardcoded upbound-system lease namespace

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -117,15 +117,27 @@ func main() {
 	kingpin.FatalIfError(mgr.Start(providerCtx), "Cannot start controller manager")
 }
 
-const saNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+const (
+	saNamespaceFile           = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	defaultLeaseNamespaceFallBack = "crossplane-system"
+)
 
 // podNamespace returns the namespace of the running pod by reading the
-// downward-API file injected by Kubernetes. Falls back to "crossplane-system"
-// when running outside a cluster (e.g. during local development).
+// downward-API file injected by Kubernetes. Falls back to the default namespace
+// when running outside a cluster (e.g. during local development) or when the
+// file exists but contains no data.
 func podNamespace() string {
-	data, err := os.ReadFile(saNamespaceFile)
+	return podNamespaceFromFile(saNamespaceFile)
+}
+
+func podNamespaceFromFile(path string) string {
+	data, err := os.ReadFile(path)
 	if err != nil {
-		return "crossplane-system"
+		return defaultLeaseNamespaceFallBack
 	}
-	return strings.TrimSpace(string(data))
+	ns := strings.TrimSpace(string(data))
+	if ns == "" {
+		return defaultLeaseNamespaceFallBack
+	}
+	return ns
 }

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/feature"
@@ -53,6 +54,7 @@ func main() {
 		artifactsHistoryLimit   = app.Flag("artifacts-history-limit", "Each attempt to run the playbook/role generates a set of artifacts on disk. This settings limits how many of these to keep.").Default("10").Int()
 		pollStateMetricInterval = app.Flag("poll-state-metric", "State metric recording interval").Default("5s").Duration()
 		replicasCount           = app.Flag("replicas", "Amount of replicas configured for the provider. When using more than 1 replica, reconciles will be sharded across them based on a modular hash.").Default("1").Uint32()
+		leaseNamespace          = app.Flag("lease-namespace", "Namespace used to create Lease objects for replica sharding. Defaults to the provider pod's own namespace.").Default(podNamespace()).String()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
@@ -107,9 +109,23 @@ func main() {
 		Timeout:                *timeout,
 		ArtifactsHistoryLimit:  *artifactsHistoryLimit,
 		ReplicasCount:          *replicasCount,
+		LeaseNamespace:         *leaseNamespace,
 		ProviderCtx:            providerCtx,
 		ProviderCancel:         cancel,
 	}
 	kingpin.FatalIfError(ansible.Setup(mgr, o, ansibleOpts), "Cannot setup Ansible controllers")
 	kingpin.FatalIfError(mgr.Start(providerCtx), "Cannot start controller manager")
+}
+
+const saNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+// podNamespace returns the namespace of the running pod by reading the
+// downward-API file injected by Kubernetes. Falls back to "crossplane-system"
+// when running outside a cluster (e.g. during local development).
+func podNamespace() string {
+	data, err := os.ReadFile(saNamespaceFile)
+	if err != nil {
+		return "crossplane-system"
+	}
+	return strings.TrimSpace(string(data))
 }

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -118,7 +118,7 @@ func main() {
 }
 
 const (
-	saNamespaceFile           = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	saNamespaceFile               = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 	defaultLeaseNamespaceFallBack = "crossplane-system"
 )
 
@@ -130,8 +130,17 @@ func podNamespace() string {
 	return podNamespaceFromFile(saNamespaceFile)
 }
 
+var namespacePathPrefix = "/var/run/secrets/"
+
 func podNamespaceFromFile(path string) string {
-	data, err := os.ReadFile(path)
+	cleanPath := filepath.Clean(path)
+	// This prefix check is defense-in-depth against path traversal (G304/CWE-22).
+	// In production the path is always the hardcoded saNamespaceFile constant,
+	// so falling back to the default namespace is acceptable.
+	if !strings.HasPrefix(cleanPath, namespacePathPrefix) {
+		return defaultLeaseNamespaceFallBack
+	}
+	data, err := os.ReadFile(cleanPath)
 	if err != nil {
 		return defaultLeaseNamespaceFallBack
 	}

--- a/cmd/provider/main_test.go
+++ b/cmd/provider/main_test.go
@@ -68,11 +68,21 @@ func TestPodNamespaceFromFile(t *testing.T) {
 			},
 			want: defaultLeaseNamespaceFallBack,
 		},
+		"PathOutsideAllowedPrefix": {
+			reason: "Should fall back to default namespace when the path is outside the allowed prefix",
+			setup: func(dir string) string {
+				return "/etc/passwd"
+			},
+			want: defaultLeaseNamespaceFallBack,
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			dir := t.TempDir()
+			oldPrefix := namespacePathPrefix
+			namespacePathPrefix = dir + string(filepath.Separator)
+			defer func() { namespacePathPrefix = oldPrefix }()
 			path := tc.setup(dir)
 			got := podNamespaceFromFile(path)
 			if got != tc.want {

--- a/cmd/provider/main_test.go
+++ b/cmd/provider/main_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPodNamespaceFromFile(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		setup  func(dir string) string
+		want   string
+	}{
+		"SuccessfulRead": {
+			reason: "Should return the namespace from the file",
+			setup: func(dir string) string {
+				path := filepath.Join(dir, "namespace")
+				if err := os.WriteFile(path, []byte("my-namespace\n"), 0600); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			want: "my-namespace",
+		},
+		"EmptyFile": {
+			reason: "Should fall back to default namespace when the file is empty",
+			setup: func(dir string) string {
+				path := filepath.Join(dir, "namespace")
+				if err := os.WriteFile(path, []byte(""), 0600); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			want: defaultLeaseNamespaceFallBack,
+		},
+		"WhitespaceOnly": {
+			reason: "Should fall back to default namespace when the file contains only whitespace",
+			setup: func(dir string) string {
+				path := filepath.Join(dir, "namespace")
+				if err := os.WriteFile(path, []byte("   \n\t\n"), 0600); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			want: defaultLeaseNamespaceFallBack,
+		},
+		"FileNotFound": {
+			reason: "Should fall back to default namespace when the file does not exist",
+			setup: func(dir string) string {
+				return filepath.Join(dir, "nonexistent")
+			},
+			want: defaultLeaseNamespaceFallBack,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := tc.setup(dir)
+			got := podNamespaceFromFile(path)
+			if got != tc.want {
+				t.Errorf("\n%s\npodNamespaceFromFile(...): want %q, got %q\n", tc.reason, tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/controller/ansibleRun/ansibleRun.go
+++ b/internal/controller/ansibleRun/ansibleRun.go
@@ -110,6 +110,7 @@ type SetupOptions struct {
 	Timeout                time.Duration
 	ArtifactsHistoryLimit  int
 	ReplicasCount          uint32
+	LeaseNamespace         string
 	ProviderCtx            context.Context
 	ProviderCancel         context.CancelFunc
 }
@@ -143,8 +144,9 @@ func Setup(mgr ctrl.Manager, o controller.Options, s SetupOptions) error {
 				ArtifactsHistoryLimit: s.ArtifactsHistoryLimit,
 			}
 		},
-		replicaID: uuid.New().String(),
-		logger:    o.Logger,
+		replicaID:      uuid.New().String(),
+		leaseNamespace: s.LeaseNamespace,
+		logger:         o.Logger,
 	}
 
 	opts := []managed.ReconcilerOption{
@@ -182,12 +184,13 @@ func Setup(mgr ctrl.Manager, o controller.Options, s SetupOptions) error {
 // A connector is expected to produce an ExternalClient when its Connect method
 // is called.
 type connector struct {
-	kube      client.Client
-	usage     resource.Tracker
-	fs        afero.Afero
-	ansible   func(dir string) params
-	replicaID string
-	logger    logging.Logger
+	kube           client.Client
+	usage          resource.Tracker
+	fs             afero.Afero
+	ansible        func(dir string) params
+	replicaID      string
+	leaseNamespace string
+	logger         logging.Logger
 }
 
 func (c *connector) Connect(ctx context.Context, cr *v1alpha1.AnsibleRun) (managed.TypedExternalClient[*v1alpha1.AnsibleRun], error) { //nolint:gocyclo
@@ -546,10 +549,9 @@ func (c *connector) generateLeaseName(index uint32) string {
 
 func (c *connector) releaseLease(ctx context.Context, kube client.Client, index uint32) error {
 	leaseName := c.generateLeaseName(index)
-	ns := "upbound-system"
 
 	lease := &coordinationv1.Lease{
-		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: leaseName},
+		ObjectMeta: metav1.ObjectMeta{Namespace: c.leaseNamespace, Name: leaseName},
 	}
 
 	return kube.Delete(ctx, lease)
@@ -562,9 +564,7 @@ func (c *connector) acquireLease(ctx context.Context, kube client.Client, index 
 	leaseName := c.generateLeaseName(index)
 	leaseDurationSeconds := ptr.To(int32(leaseDurationSeconds))
 
-	ns := "upbound-system"
-
-	if err := kube.Get(ctx, client.ObjectKey{Namespace: ns, Name: leaseName}, lease); err != nil {
+	if err := kube.Get(ctx, client.ObjectKey{Namespace: c.leaseNamespace, Name: leaseName}, lease); err != nil {
 		if !kerrors.IsNotFound(err) {
 			return err
 		}
@@ -573,7 +573,7 @@ func (c *connector) acquireLease(ctx context.Context, kube client.Client, index 
 		lease = &coordinationv1.Lease{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      leaseName,
-				Namespace: ns,
+				Namespace: c.leaseNamespace,
 			},
 			Spec: coordinationv1.LeaseSpec{
 				HolderIdentity:       &c.replicaID,
@@ -613,8 +613,13 @@ func (c *connector) acquireLease(ctx context.Context, kube client.Client, index 
 }
 
 // Finds an available shard and acquires a lease for it. Will attempt to obtain one indefinitely.
-// This will also start a background go-routine to renew the lease continuously and release it when the process receives a shutdown signal
+// This will also start a background go-routine to renew the lease continuously and release it when the process receives a shutdown signal.
+// When ReplicasCount is 1, lease acquisition is skipped and shard 0 is returned immediately.
 func (c *connector) acquireAndHoldShard(o controller.Options, s SetupOptions) (uint32, error) {
+	if s.ReplicasCount == 1 {
+		return 0, nil
+	}
+
 	ctx := s.ProviderCtx
 	var currentShard uint32
 

--- a/internal/controller/ansibleRun/ansibleRun.go
+++ b/internal/controller/ansibleRun/ansibleRun.go
@@ -621,7 +621,6 @@ func (c *connector) acquireAndHoldShard(o controller.Options, s SetupOptions) (u
 	}
 
 	ctx := s.ProviderCtx
-	var currentShard uint32
 
 	cfg := ctrl.GetConfigOrDie()
 	kube, err := client.New(cfg, client.Options{})
@@ -629,43 +628,46 @@ func (c *connector) acquireAndHoldShard(o controller.Options, s SetupOptions) (u
 		return 0, err
 	}
 
-AcquireLease:
 	for {
-		for i := uint32(0); i < s.ReplicasCount; i++ {
-			if err := c.acquireLease(ctx, kube, i); err == nil {
-				currentShard = i
-				o.Logger.Debug("acquired lease", "id", i)
-				go func() {
-					sigHandler := ctrl.SetupSignalHandler()
-
-					for {
-						select {
-						case <-time.After(leaseRenewalInterval):
-							if err := c.acquireLease(ctx, kube, i); err != nil {
-								o.Logger.Info("failed to renew lease", "id", i, "err", err)
-								s.ProviderCancel()
-							} else {
-								o.Logger.Debug("renewed lease", "id", i)
-							}
-						case <-sigHandler.Done():
-							o.Logger.Info("controller is shutting down, releasing lease")
-							if err := c.releaseLease(ctx, kube, i); err != nil {
-								o.Logger.Info("failed to release lease", "lease", err)
-							}
-							o.Logger.Debug("released lease")
-							s.ProviderCancel()
-							return
-						}
-					}
-				}()
-				// Lease is acquired and background goroutine started for renewal, we can safely break to return the current shard
-				break AcquireLease
-			} else {
-				o.Logger.Debug("cannot acquire lease", "id", i, "err", err)
-				time.Sleep(leaseAcquireAttemptInterval)
-			}
+		if shard, ok := c.tryAcquireShard(ctx, kube, o, s); ok {
+			return shard, nil
 		}
 	}
+}
 
-	return currentShard, nil
+func (c *connector) tryAcquireShard(ctx context.Context, kube client.Client, o controller.Options, s SetupOptions) (uint32, bool) {
+	for i := uint32(0); i < s.ReplicasCount; i++ {
+		if err := c.acquireLease(ctx, kube, i); err != nil {
+			o.Logger.Debug("cannot acquire lease", "id", i, "err", err)
+			time.Sleep(leaseAcquireAttemptInterval)
+			continue
+		}
+		o.Logger.Debug("acquired lease", "id", i)
+		go c.holdShard(ctx, kube, i, o, s)
+		return i, true
+	}
+	return 0, false
+}
+
+func (c *connector) holdShard(ctx context.Context, kube client.Client, i uint32, o controller.Options, s SetupOptions) {
+	sigHandler := ctrl.SetupSignalHandler()
+	for {
+		select {
+		case <-time.After(leaseRenewalInterval):
+			if err := c.acquireLease(ctx, kube, i); err != nil {
+				o.Logger.Info("failed to renew lease", "id", i, "err", err)
+				s.ProviderCancel()
+			} else {
+				o.Logger.Debug("renewed lease", "id", i)
+			}
+		case <-sigHandler.Done():
+			o.Logger.Info("controller is shutting down, releasing lease")
+			if err := c.releaseLease(ctx, kube, i); err != nil {
+				o.Logger.Info("failed to release lease", "lease", err)
+			}
+			o.Logger.Debug("released lease")
+			s.ProviderCancel()
+			return
+		}
+	}
 }

--- a/internal/controller/ansibleRun/ansibleRun_test.go
+++ b/internal/controller/ansibleRun/ansibleRun_test.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
@@ -1005,6 +1006,40 @@ func TestDelete(t *testing.T) {
 			_, err := e.Delete(tc.args.ctx, tc.args.cr)
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Delete(...): -want error, +got error:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestAcquireAndHoldShard(t *testing.T) {
+	cases := map[string]struct {
+		reason  string
+		conn    connector
+		opts    controller.Options
+		setup   SetupOptions
+		want    uint32
+		wantErr error
+	}{
+		"SingleReplica": {
+			reason: "When ReplicasCount is 1 no lease should be acquired and shard 0 should be returned immediately",
+			conn:   connector{},
+			opts:   controller.Options{},
+			setup: SetupOptions{
+				ReplicasCount: 1,
+			},
+			want:    0,
+			wantErr: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := tc.conn.acquireAndHoldShard(tc.opts, tc.setup)
+			if diff := cmp.Diff(tc.wantErr, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nacquireAndHoldShard(...): -want error, +got error:\n%s\n", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nacquireAndHoldShard(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
 	}


### PR DESCRIPTION
The provider was hardcoding upbound-system as the namespace for Kubernetes Lease objects used in replica sharding. This caused the provider to silently fail to reconcile any AnsibleRun resources when deployed outside of Upbound environments where that namespace doesn't exist.

Two things are fixed here:

First, the lease namespace is now configurable via a --lease-namespace flag. By default it reads the pod's own namespace from the downward API (/var/run/secrets/kubernetes.io/serviceaccount/namespace), falling back to crossplane-system when running locally outside a cluster.

Second, when running with a single replica (the default), the provider no longer tries to acquire a lease at all — there's nothing to shard, so the whole lease dance was unnecessary overhead that also happened to be the root cause of the reported failure.

Fixes #408